### PR TITLE
Use `_best` as the default for TESSDATA_REPO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ LEPTONICA_VERSION := 1.75.3
 TESSERACT_VERSION := fd492062d08a2f55001a639f2015b8524c7e9ad4
 
 # Tesseract model repo to use. Default: $(TESSDATA_REPO)
-TESSDATA_REPO = _fast
+TESSDATA_REPO = _best
 
 # Ground truth directory. Default: $(GROUND_TRUTH_DIR)
 GROUND_TRUTH_DIR := data/ground-truth


### PR DESCRIPTION
As requested by @Shreeshrii.

Fixes https://github.com/OCR-D/ocrd-train/issues/55